### PR TITLE
Adds the ability to write custom notes for individual flow nodes. (~2948)

### DIFF
--- a/release-notes.xml
+++ b/release-notes.xml
@@ -33,6 +33,6 @@
   </ChangeSet>
   <ChangeSet>
     <Change type="feature">Adds the ability to write custom notes for individual flow nodes.</Change>
-    <Change type="feature">The notes textbox resizes automatically depending on the number of lines but the containing control can also be resized manually using a grid divider.</Change>
+    <Change type="feature">The notes textbox resizes automatically depending on the number of lines but the containing control can also be resized manually using a grid splitter.</Change>
   </ChangeSet>
 </ReleaseNotes>

--- a/release-notes.xml
+++ b/release-notes.xml
@@ -31,4 +31,7 @@
   <ChangeSet guid="acc0a9a0-e864-4d9a-97e5-f31a287781a1">
     <Change type="feature">Adds the ability to view a node documentation via a node context menu entry.</Change>
   </ChangeSet>
+  <ChangeSet>
+    <Change type="feature">Adds the ability to write custom notes for individual flow nodes.</Change>
+  </ChangeSet>
 </ReleaseNotes>

--- a/release-notes.xml
+++ b/release-notes.xml
@@ -33,6 +33,6 @@
   </ChangeSet>
   <ChangeSet>
     <Change type="feature">Adds the ability to write custom notes for individual flow nodes.</Change>
-    <Change type="feature">The notes textbox resizes automatically depending on the number of lines but can also be resized manually using a grid divider.</Change>
+    <Change type="feature">The notes textbox resizes automatically depending on the number of lines but the containing control can also be resized manually using a grid divider.</Change>
   </ChangeSet>
 </ReleaseNotes>

--- a/release-notes.xml
+++ b/release-notes.xml
@@ -33,5 +33,6 @@
   </ChangeSet>
   <ChangeSet>
     <Change type="feature">Adds the ability to write custom notes for individual flow nodes.</Change>
+    <Change type="feature">The notes textbox resizes automatically depending on the number of lines but can also be resized manually using a grid divider.</Change>
   </ChangeSet>
 </ReleaseNotes>

--- a/src/Simplic.Flow.Configuration/Model/NodeConfiguration.cs
+++ b/src/Simplic.Flow.Configuration/Model/NodeConfiguration.cs
@@ -14,5 +14,10 @@ namespace Simplic.Flow.Configuration
         public double PositionY { get; set; }
         public double Width { get; set; }
         public double Height { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user notes.
+        /// </summary>
+        public string UserNotes { get; set; }
     }
 }

--- a/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
+++ b/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
@@ -54,90 +54,99 @@
                                                   HorizontalAlignment="Right"
                                                   IsExpanded="True"/>
 
-                <TabControl Grid.Column="2" Grid.Row="0" Padding="5">
+                <Grid Grid.Column="2" Grid.Row="0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="auto"/>
+                        <RowDefinition Height="auto"/>
+                        <RowDefinition Height="auto"/>
+                    </Grid.RowDefinitions>
+                    
+                    
+                    <TabControl Grid.Row="0" Padding="5">
 
-                    <TabItem Header="{simplic:Localization Key=flow_tab_header}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="auto" />
-                                <RowDefinition Height="auto" />
-                                <RowDefinition Height="auto" />
-                                <RowDefinition Height="auto" />
-                                <RowDefinition Height="auto" />
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
+                        <TabItem Header="{simplic:Localization Key=flow_tab_header}">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="auto" />
+                                    <RowDefinition Height="auto" />
+                                    <RowDefinition Height="auto" />
+                                    <RowDefinition Height="auto" />
+                                    <RowDefinition Height="auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
 
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
 
-                            <Label Grid.Row="0" Content="Name" FontWeight="Bold"/>
-                            <simplic:TextBox Grid.Row="0" Grid.Column="1"
+                                <Label Grid.Row="0" Content="Name" FontWeight="Bold"/>
+                                <simplic:TextBox Grid.Row="0" Grid.Column="1"
                                              Text="{Binding WorkflowName, UpdateSourceTrigger=PropertyChanged}" />
 
-                            <Label Grid.Row="1" Content="Server" FontWeight="Bold"/>
-                            <simplic:TextBox Grid.Row="1" Grid.Column="1"
+                                <Label Grid.Row="1" Content="Server" FontWeight="Bold"/>
+                                <simplic:TextBox Grid.Row="1" Grid.Column="1"
                                              Text="{Binding MachineName, UpdateSourceTrigger=PropertyChanged}" />
 
-                            <Label Grid.Row="2" Content="Service Name" FontWeight="Bold"/>
-                            <simplic:TextBox Grid.Row="2" Grid.Column="1"
+                                <Label Grid.Row="2" Content="Service Name" FontWeight="Bold"/>
+                                <simplic:TextBox Grid.Row="2" Grid.Column="1"
                                              Text="{Binding ServiceName, UpdateSourceTrigger=PropertyChanged}" />
 
-                            <simplic:CheckBox Content="{simplic:Localization Key=flow_is_active}"
+                                <simplic:CheckBox Content="{simplic:Localization Key=flow_is_active}"
                                               Grid.Row="3" Grid.ColumnSpan="2"
                                               IsChecked="{Binding IsActive, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-                            <Button Grid.Row="4" Grid.ColumnSpan="2" HorizontalAlignment="Left"
+                                <Button Grid.Row="4" Grid.ColumnSpan="2" HorizontalAlignment="Left"
                                     Margin="0, 5" Width="150"
                                     Content="{simplic:Localization Key=flow_new_variable}"
                                     Command="{Binding AddVariableCommand}" />
 
-                            <TabControl Grid.Row="5" Grid.ColumnSpan="2">
-                                <TabItem Header="{simplic:Localization Key=flow_variables}">
-                                    <Grid>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="*"/>
-                                        </Grid.RowDefinitions>
+                                <TabControl Grid.Row="5" Grid.ColumnSpan="2">
+                                    <TabItem Header="{simplic:Localization Key=flow_variables}">
+                                        <Grid>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="*"/>
+                                            </Grid.RowDefinitions>
 
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
 
-                                        <simplic:AutomaticSelectionGridView Grid.Row="0" Grid.Column="0"
+                                            <simplic:AutomaticSelectionGridView Grid.Row="0" Grid.Column="0"
                                                                             ItemsSource="{Binding Variables}"
                                                                             AutoGenerateColumns="False" 
                                                                             CanUserInsertRows="True"
                                                                             CanUserDeleteRows="True"
                                                                             ShowGroupPanel="True">
-                                            <simplic:AutomaticSelectionGridView.Columns>
-                                                <telerik:GridViewDataColumn DataMemberBinding="{Binding Name}"
+                                                <simplic:AutomaticSelectionGridView.Columns>
+                                                    <telerik:GridViewDataColumn DataMemberBinding="{Binding Name}"
                                                                             Header="{simplic:Localization Key=flow_variable_name}" />
-                                                <telerik:GridViewComboBoxColumn ItemsSource="{Binding AvailableVariableTypes}"
+                                                    <telerik:GridViewComboBoxColumn ItemsSource="{Binding AvailableVariableTypes}"
                                                                                 DataMemberBinding="{Binding Type}"
                                                                                 Header="{simplic:Localization Key=flow_variable_name}" />
-                                            </simplic:AutomaticSelectionGridView.Columns>
-                                        </simplic:AutomaticSelectionGridView>
-                                    </Grid>
-                                </TabItem>
-                            </TabControl>
+                                                </simplic:AutomaticSelectionGridView.Columns>
+                                            </simplic:AutomaticSelectionGridView>
+                                        </Grid>
+                                    </TabItem>
+                                </TabControl>
 
-                        </Grid>
-                    </TabItem>
+                            </Grid>
+                        </TabItem>
 
-                    <TabItem Header="{simplic:Localization Key=flow_available_nodes}" Padding="5">
-                        <Grid x:Name="toolbox">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="40"/>
-                                <RowDefinition Height="*"/>
-                            </Grid.RowDefinitions>
+                        <TabItem Header="{simplic:Localization Key=flow_available_nodes}" Padding="5">
+                            <Grid x:Name="toolbox">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="40"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
 
-                            <local:SearchControl Width="auto"
+                                <local:SearchControl Width="auto"
                                                  SearchTerm="{Binding SearchTerm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                  Watermark="{simplic:Localization Key=search}"
                                                  MatchCase="{Binding MatchCase}"
                                                  MatchWholeWord="{Binding MatchWholeWord}"/>
-                            <telerik:RadDiagramToolbox Grid.Row="1" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
+                                <telerik:RadDiagramToolbox Grid.Row="1" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
                                                        Title="{simplic:Localization Key=flow_available_nodes}"
                                                        ItemsSource="{Binding GalleryItems}"
                                                        SelectedItem="{Binding SelectedGallery}"
@@ -146,9 +155,27 @@
                                                        SelectiveScrollingGrid.SelectiveScrollingOrientation="Both"
                                                        Template="{StaticResource CustomDiagramToolBoxTemplate}"
                                                        IsTextSearchEnabled="True" />
-                        </Grid>
-                    </TabItem>
-                </TabControl>
+                            </Grid>
+                        </TabItem>
+                    </TabControl>
+
+                    <GridSplitter Grid.Row="1"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Center"
+                                  Background="Black"
+                                  ShowsPreview="True"
+                                  Height="5"/>
+
+                    <Grid Grid.Row="2">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        
+                        <Label Content="{simplic:Localization Key=flow_notes}" Grid.Row="0"/>
+                        <simplic:TextBox Text="{Binding SelectedNode.UserNotes, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" TextWrapping="Wrap" AcceptsReturn="True" VerticalAlignment="Top" Height="auto" Grid.Row="1" Margin="5"/>
+                    </Grid>
+                </Grid>
             </Grid>
         </telerik:RadTabItem>
         <telerik:RadTabItem Header="Playground" IsEnabled="False">

--- a/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
+++ b/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
@@ -172,7 +172,13 @@
                         </Grid.RowDefinitions>
                         
                         <Label Content="{simplic:Localization Key=flow_notes}" Grid.Row="0"/>
-                        <simplic:TextBox Text="{Binding SelectedNode.UserNotes, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" TextWrapping="Wrap" AcceptsReturn="True" VerticalAlignment="Top" Height="auto" Grid.Row="1" Margin="5"/>
+                        <simplic:TextBox Text="{Binding SelectedNode.UserNotes, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                                         TextWrapping="Wrap"
+                                         AcceptsReturn="True"
+                                         VerticalAlignment="Top"
+                                         Height="auto"
+                                         Grid.Row="1"
+                                         Margin="5"/>
                     </Grid>
                 </Grid>
             </Grid>

--- a/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
+++ b/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
@@ -59,7 +59,6 @@
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="auto"/>
                         <RowDefinition Height="auto"/>
-                        <RowDefinition Height="auto"/>
                     </Grid.RowDefinitions>
                     
                     

--- a/src/Simplic.Flow.Editor.UI/Resources.xaml
+++ b/src/Simplic.Flow.Editor.UI/Resources.xaml
@@ -181,7 +181,6 @@
             <Setter.Value>
                 <ContextMenu>
                     <MenuItem Header="{simplic:Localization Key=flow_documentation_show}" Command="{Binding ShowDocumentationCommand}"/>
-                    <MenuItem Header="Show/edit user notes" Command="{Binding EditUserNotesCommand}"/>
                 </ContextMenu>
             </Setter.Value>
         </Setter>
@@ -200,7 +199,6 @@
             <Setter.Value>
                 <ContextMenu>
                     <MenuItem Header="{simplic:Localization Key=flow_documentation_show}" Command="{Binding ShowDocumentationCommand}"/>
-                    <MenuItem Header="Show/edit user notes" Command="{Binding EditUserNotesCommand}"/>
                     <MenuItem Header="Defaultwerte" Command="{Binding OpenDefaultValueEditor}" CommandParameter="{Binding}" />
                 </ContextMenu>
             </Setter.Value>

--- a/src/Simplic.Flow.Editor.UI/Resources.xaml
+++ b/src/Simplic.Flow.Editor.UI/Resources.xaml
@@ -181,6 +181,7 @@
             <Setter.Value>
                 <ContextMenu>
                     <MenuItem Header="{simplic:Localization Key=flow_documentation_show}" Command="{Binding ShowDocumentationCommand}"/>
+                    <MenuItem Header="Show/edit user notes" Command="{Binding EditUserNotesCommand}"/>
                 </ContextMenu>
             </Setter.Value>
         </Setter>
@@ -199,6 +200,7 @@
             <Setter.Value>
                 <ContextMenu>
                     <MenuItem Header="{simplic:Localization Key=flow_documentation_show}" Command="{Binding ShowDocumentationCommand}"/>
+                    <MenuItem Header="Show/edit user notes" Command="{Binding EditUserNotesCommand}"/>
                     <MenuItem Header="Defaultwerte" Command="{Binding OpenDefaultValueEditor}" CommandParameter="{Binding}" />
                 </ContextMenu>
             </Setter.Value>

--- a/src/Simplic.Flow.Editor.UI/ViewModel/Node/NodeViewModel.cs
+++ b/src/Simplic.Flow.Editor.UI/ViewModel/Node/NodeViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using Simplic.Flow.Configuration;
 using Simplic.Flow.Editor.Definition;
-using Simplic.Framework.UI;
 using Simplic.Localization;
 using Simplic.UI.MVC;
 using System;

--- a/src/Simplic.Flow.Editor.UI/ViewModel/Node/NodeViewModel.cs
+++ b/src/Simplic.Flow.Editor.UI/ViewModel/Node/NodeViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Simplic.Flow.Configuration;
 using Simplic.Flow.Editor.Definition;
+using Simplic.Framework.UI;
 using Simplic.Localization;
 using Simplic.UI.MVC;
 using System;
@@ -26,6 +27,7 @@ namespace Simplic.Flow.Editor.UI
         private ObservableCollection<DataPinDefaultValueViewModel> defaultValues;
 
         private ICommand showDocumentationCommand;
+        private ICommand editUserNotesCommand;
 
         private readonly ILocalizationService localizationService;
         #endregion
@@ -42,6 +44,7 @@ namespace Simplic.Flow.Editor.UI
             this.nodeConfiguration = nodeConfiguration;
 
             this.showDocumentationCommand = new RelayCommand(ShowDocumentation);
+            this.editUserNotesCommand = new RelayCommand(EditUserNotes);
 
             this.localizationService = CommonServiceLocator.ServiceLocator.Current.GetInstance<ILocalizationService>();
 
@@ -148,6 +151,18 @@ namespace Simplic.Flow.Editor.UI
                 return;
 
             MessageBox.Show(localizationService.Translate("flow_documentation_not_found"), localizationService.Translate("flow_documentation_not_found_title"), MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+
+        /// <summary>
+        /// Shows the user notes in an edit window.
+        /// </summary>
+        /// <param name="o"></param>
+        private void EditUserNotes(object o)
+        {
+            var input = Window_InputDialog.Show("Edit user notes", "User notes", nodeConfiguration.UserNotes);
+
+            if (!string.IsNullOrWhiteSpace(input))
+                nodeConfiguration.UserNotes = input;
         }
 
         /// <summary>
@@ -318,13 +333,23 @@ namespace Simplic.Flow.Editor.UI
         /// </summary>
         public ICommand ShowDocumentationCommand => showDocumentationCommand;
 
+        /// <summary>
+        /// Gets or sets the command to show or edit the user notes.
+        /// </summary>
+        public ICommand EditUserNotesCommand => editUserNotesCommand;
+
         #region [DefaultValues]
         public ObservableCollection<DataPinDefaultValueViewModel> DefaultValues
         {
             get { return defaultValues; }
             set { defaultValues = value; RaisePropertyChanged(nameof(DefaultValues)); }
-        } 
+        }
         #endregion
+
+        /// <summary>
+        /// Gets or sets the user notes.
+        /// </summary>
+        public string UserNotes => nodeConfiguration.UserNotes;
 
         #endregion
     }

--- a/src/Simplic.Flow.Editor.UI/ViewModel/Node/NodeViewModel.cs
+++ b/src/Simplic.Flow.Editor.UI/ViewModel/Node/NodeViewModel.cs
@@ -349,7 +349,20 @@ namespace Simplic.Flow.Editor.UI
         /// <summary>
         /// Gets or sets the user notes.
         /// </summary>
-        public string UserNotes => nodeConfiguration.UserNotes;
+        public string UserNotes
+        {
+            get
+            {
+                return nodeConfiguration.UserNotes;
+            }
+
+            set
+            {
+                nodeConfiguration.UserNotes = value;
+                IsDirty = true;
+                RaisePropertyChanged(nameof(UserNotes));
+            }
+        }
 
         #endregion
     }

--- a/src/Simplic.Flow.Editor.UI/ViewModel/Node/NodeViewModel.cs
+++ b/src/Simplic.Flow.Editor.UI/ViewModel/Node/NodeViewModel.cs
@@ -27,7 +27,6 @@ namespace Simplic.Flow.Editor.UI
         private ObservableCollection<DataPinDefaultValueViewModel> defaultValues;
 
         private ICommand showDocumentationCommand;
-        private ICommand editUserNotesCommand;
 
         private readonly ILocalizationService localizationService;
         #endregion
@@ -44,7 +43,6 @@ namespace Simplic.Flow.Editor.UI
             this.nodeConfiguration = nodeConfiguration;
 
             this.showDocumentationCommand = new RelayCommand(ShowDocumentation);
-            this.editUserNotesCommand = new RelayCommand(EditUserNotes);
 
             this.localizationService = CommonServiceLocator.ServiceLocator.Current.GetInstance<ILocalizationService>();
 
@@ -151,18 +149,6 @@ namespace Simplic.Flow.Editor.UI
                 return;
 
             MessageBox.Show(localizationService.Translate("flow_documentation_not_found"), localizationService.Translate("flow_documentation_not_found_title"), MessageBoxButton.OK, MessageBoxImage.Error);
-        }
-
-        /// <summary>
-        /// Shows the user notes in an edit window.
-        /// </summary>
-        /// <param name="o"></param>
-        private void EditUserNotes(object o)
-        {
-            var input = Window_InputDialog.Show("Edit user notes", "User notes", nodeConfiguration.UserNotes);
-
-            if (!string.IsNullOrWhiteSpace(input))
-                nodeConfiguration.UserNotes = input;
         }
 
         /// <summary>
@@ -332,11 +318,6 @@ namespace Simplic.Flow.Editor.UI
         /// Gets or sets the command to show the documentation for this node in the default system browser.
         /// </summary>
         public ICommand ShowDocumentationCommand => showDocumentationCommand;
-
-        /// <summary>
-        /// Gets or sets the command to show or edit the user notes.
-        /// </summary>
-        public ICommand EditUserNotesCommand => editUserNotesCommand;
 
         #region [DefaultValues]
         public ObservableCollection<DataPinDefaultValueViewModel> DefaultValues


### PR DESCRIPTION
![Screenshot 2022-03-16 154925](https://user-images.githubusercontent.com/50635429/158617921-8b7fbdf8-b2cc-42f5-a647-455baeaa3fff.png)

The notes textbox resizes automatically depending on the number of lines but the containing control can also be resized manually using a grid divider.