### PR TITLE
Make the user notes text box stretch automatically when manually changing user notes control size (~2948)

### DIFF
--- a/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
+++ b/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
@@ -172,11 +172,11 @@
                         </Grid.RowDefinitions>
                         
                         <Label Content="{simplic:Localization Key=flow_notes}" Grid.Row="0"/>
-                        <simplic:TextBox Text="{Binding SelectedNode.UserNotes, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                        <TextBox Text="{Binding SelectedNode.UserNotes, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                                          TextWrapping="Wrap"
                                          AcceptsReturn="True"
-                                         VerticalAlignment="Top"
-                                         Height="auto"
+                                         VerticalAlignment="Stretch"
+                                         VerticalScrollBarVisibility="Auto"
                                          Grid.Row="1"
                                          Margin="5"/>
                     </Grid>


### PR DESCRIPTION
It was necessary to change from simplic:TextBox to TextBox for stretching to work.