### PR TITLE
Add lazy loading for loading available nodes in flow editor (~2949)

### DIFF
--- a/release-notes.xml
+++ b/release-notes.xml
@@ -31,4 +31,7 @@
   <ChangeSet guid="acc0a9a0-e864-4d9a-97e5-f31a287781a1">
     <Change type="feature">Adds the ability to view a node documentation via a node context menu entry.</Change>
   </ChangeSet>
+  <ChangeSet>
+    <Change type="feature">Applies lazy loading to available nodes in order to prevent the UI from freezing when opening the available nodes tab for the first time.</Change>
+  </ChangeSet>
 </ReleaseNotes>

--- a/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
+++ b/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
@@ -145,7 +145,7 @@
                                                        ItemTemplate="{StaticResource ToolboxTemplate}"
                                                        SelectiveScrollingGrid.SelectiveScrollingOrientation="Both"
                                                        Template="{StaticResource CustomDiagramToolBoxTemplate}"
-                                                       IsTextSearchEnabled="True"/>
+                                                       IsTextSearchEnabled="True" />
                         </Grid>
                     </TabItem>
                 </TabControl>

--- a/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
+++ b/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
@@ -54,7 +54,7 @@
                                                   HorizontalAlignment="Right"
                                                   IsExpanded="True"/>
 
-                <TabControl Grid.Column="2" Grid.Row="0" Padding="5">
+                <TabControl Grid.Column="2" Grid.Row="0" Padding="5" SelectionChanged="TabControl_SelectionChanged">
 
                     <TabItem Header="{simplic:Localization Key=flow_tab_header}">
                         <Grid>

--- a/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
+++ b/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml
@@ -145,7 +145,7 @@
                                                        ItemTemplate="{StaticResource ToolboxTemplate}"
                                                        SelectiveScrollingGrid.SelectiveScrollingOrientation="Both"
                                                        Template="{StaticResource CustomDiagramToolBoxTemplate}"
-                                                       IsTextSearchEnabled="True" />
+                                                       IsTextSearchEnabled="True"/>
                         </Grid>
                     </TabItem>
                 </TabControl>

--- a/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml.cs
+++ b/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml.cs
@@ -161,7 +161,7 @@ namespace Simplic.Flow.Editor.UI
 
         private void TabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            toolboxViewModel.CheckAvailableNodesLoaded();
+            toolboxViewModel.LazyLoadAvailableNodes();
         }
     }
 }

--- a/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml.cs
+++ b/src/Simplic.Flow.Editor.UI/FlowEditorControl.xaml.cs
@@ -18,6 +18,8 @@ namespace Simplic.Flow.Editor.UI
         private WorkflowEditorViewModel diagramViewModel;
         private bool isInitialized = false;
 
+        private ToolboxViewModel toolboxViewModel;
+
         /// <summary>
         /// Instantiates the flow editor control.
         /// </summary>
@@ -121,7 +123,8 @@ namespace Simplic.Flow.Editor.UI
         {
             isInitialized = true;
 
-            toolbox.DataContext = new ToolboxViewModel(nodeDefinitions);
+            toolboxViewModel = new ToolboxViewModel(nodeDefinitions);
+            toolbox.DataContext = toolboxViewModel;
 
             diagramViewModel = new WorkflowEditorViewModel(nodeDefinitions, flowConfiguration);
             this.DataContext = diagramViewModel;
@@ -154,6 +157,11 @@ namespace Simplic.Flow.Editor.UI
         public Configuration.FlowConfiguration GetFlowConfiguration()
         {
             return diagramViewModel.GetFlowConfiguration();
+        }
+
+        private void TabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            toolboxViewModel.CheckAvailableNodesLoaded();
         }
     }
 }

--- a/src/Simplic.Flow.Editor.UI/ViewModel/ToolboxViewModel.cs
+++ b/src/Simplic.Flow.Editor.UI/ViewModel/ToolboxViewModel.cs
@@ -45,7 +45,7 @@ namespace Simplic.Flow.Editor.UI
             GalleryItemsViewSource.Filter = LazyLoadingGalleryFilter;
 
             timer2 = new DispatcherTimer();
-            timer2.Interval = TimeSpan.FromSeconds(0.3);
+            timer2.Interval = TimeSpan.FromSeconds(0.5);
             timer2.Tick += Timer2_Tick;
             timer2.Start();
         }
@@ -230,10 +230,10 @@ namespace Simplic.Flow.Editor.UI
         }
         private async void Timer2_Tick(object sender, EventArgs e)
         {
-            if (maxLoadedItems == GalleryItems.Count)
+            if (maxLoadedItems > GalleryItems.Count)
                 timer2.Stop();
 
-            maxLoadedItems++;
+            maxLoadedItems += 5;
             await UpdateToolBox();
         }
 

--- a/src/Simplic.Flow.Editor.UI/ViewModel/ToolboxViewModel.cs
+++ b/src/Simplic.Flow.Editor.UI/ViewModel/ToolboxViewModel.cs
@@ -34,16 +34,16 @@ namespace Simplic.Flow.Editor.UI
             LoadGalleryItems();
         }
 
-        public void CheckAvailableNodesLoaded()
+        /// <summary>
+        /// Ensures only nodes of selected category are loaded when opening the available nodes tab for the first time.
+        /// </summary>
+        public void LazyLoadAvailableNodes()
         {
             if (loaded)
                 return;
-
             loaded = true;
 
-            foreach (var gallery in GalleryViewSources)
-                if (gallery.Key != selectedGallery)
-                    gallery.Value.Filter = LazyLoadingGalleryItemFilter;
+            GalleryViewSources.Where(x => x.Key == selectedGallery).First().Value.Filter = nodeFilter;
         }
 
         /// <summary>
@@ -103,7 +103,9 @@ namespace Simplic.Flow.Editor.UI
                 }
                 GalleryItems.Add(gallery);
                 GalleryViewSources[gallery] = CollectionViewSource.GetDefaultView(gallery.Items);
-                GalleryViewSources[gallery].Filter = nodeFilter;
+
+                // Initialize gallery to not load nodes to enable lazy loading.
+                GalleryViewSources[gallery].Filter = (x => false);
             }
 
             SelectedGallery = GalleryItems.FirstOrDefault();
@@ -215,11 +217,6 @@ namespace Simplic.Flow.Editor.UI
             }
         }
 
-        private bool LazyLoadingGalleryItemFilter(object obj)
-        {
-            return false;
-        }
-
         /// <summary>
         /// Gets or sets the collection of galleries.
         /// </summary>
@@ -243,7 +240,17 @@ namespace Simplic.Flow.Editor.UI
         /// <summary>
         /// Gets or sets the currently selected gallery.
         /// </summary>
-        public Gallery SelectedGallery { get => selectedGallery; set { selectedGallery = value; GalleryViewSources.Where(x => x.Key == value).First().Value.Filter = nodeFilter; RaisePropertyChanged(nameof(SelectedGallery)); } }
+        public Gallery SelectedGallery
+        {
+            get => selectedGallery;
+            
+            set
+            {
+                selectedGallery = value;
+                GalleryViewSources.Where(x => x.Key == value).First().Value.Filter = nodeFilter;
+                RaisePropertyChanged(nameof(SelectedGallery));
+            }
+        }
 
         /// <summary>
         /// Gets or sets the search term.

--- a/src/Simplic.Flow.Editor.UI/ViewModel/ToolboxViewModel.cs
+++ b/src/Simplic.Flow.Editor.UI/ViewModel/ToolboxViewModel.cs
@@ -22,8 +22,6 @@ namespace Simplic.Flow.Editor.UI
         private DispatcherTimer timer;
         private int keyCounter;
         private bool loaded;
-        private int maxLoadedItems;
-        private DispatcherTimer timer2;
 
         /// <summary>
         /// Instantiates the ToolboxViewModel.
@@ -42,12 +40,10 @@ namespace Simplic.Flow.Editor.UI
                 return;
 
             loaded = true;
-            GalleryItemsViewSource.Filter = LazyLoadingGalleryFilter;
 
-            timer2 = new DispatcherTimer();
-            timer2.Interval = TimeSpan.FromSeconds(0.5);
-            timer2.Tick += Timer2_Tick;
-            timer2.Start();
+            foreach (var gallery in GalleryViewSources)
+                if (gallery.Key != selectedGallery)
+                    gallery.Value.Filter = LazyLoadingGalleryItemFilter;
         }
 
         /// <summary>
@@ -219,22 +215,9 @@ namespace Simplic.Flow.Editor.UI
             }
         }
 
-        private bool LazyLoadingGalleryFilter(object obj)
+        private bool LazyLoadingGalleryItemFilter(object obj)
         {
-            var gallery = obj as Gallery;
-
-            if (GalleryItems.IndexOf(gallery) + 1 > maxLoadedItems)
-                return false;
-
-            return true;
-        }
-        private async void Timer2_Tick(object sender, EventArgs e)
-        {
-            if (maxLoadedItems > GalleryItems.Count)
-                timer2.Stop();
-
-            maxLoadedItems += 5;
-            await UpdateToolBox();
+            return false;
         }
 
         /// <summary>
@@ -260,7 +243,7 @@ namespace Simplic.Flow.Editor.UI
         /// <summary>
         /// Gets or sets the currently selected gallery.
         /// </summary>
-        public Gallery SelectedGallery { get => selectedGallery; set { selectedGallery = value; RaisePropertyChanged(nameof(SelectedGallery)); } }
+        public Gallery SelectedGallery { get => selectedGallery; set { selectedGallery = value; GalleryViewSources.Where(x => x.Key == value).First().Value.Filter = nodeFilter; RaisePropertyChanged(nameof(SelectedGallery)); } }
 
         /// <summary>
         /// Gets or sets the search term.

--- a/src/Simplic.Flow.Editor.UI/ViewModel/ToolboxViewModel.cs
+++ b/src/Simplic.Flow.Editor.UI/ViewModel/ToolboxViewModel.cs
@@ -21,6 +21,9 @@ namespace Simplic.Flow.Editor.UI
         private string searchTerm;
         private DispatcherTimer timer;
         private int keyCounter;
+        private bool loaded;
+        private int maxLoadedItems;
+        private DispatcherTimer timer2;
 
         /// <summary>
         /// Instantiates the ToolboxViewModel.
@@ -31,6 +34,20 @@ namespace Simplic.Flow.Editor.UI
             NodeDefinitions = nodeDefinitions;
             Initialize();
             LoadGalleryItems();
+        }
+
+        public void CheckAvailableNodesLoaded()
+        {
+            if (loaded)
+                return;
+
+            loaded = true;
+            GalleryItemsViewSource.Filter = LazyLoadingGalleryFilter;
+
+            timer2 = new DispatcherTimer();
+            timer2.Interval = TimeSpan.FromSeconds(0.3);
+            timer2.Tick += Timer2_Tick;
+            timer2.Start();
         }
 
         /// <summary>
@@ -200,6 +217,24 @@ namespace Simplic.Flow.Editor.UI
                 keyCounter = 0;
                 timer.Stop();
             }
+        }
+
+        private bool LazyLoadingGalleryFilter(object obj)
+        {
+            var gallery = obj as Gallery;
+
+            if (GalleryItems.IndexOf(gallery) + 1 > maxLoadedItems)
+                return false;
+
+            return true;
+        }
+        private async void Timer2_Tick(object sender, EventArgs e)
+        {
+            if (maxLoadedItems == GalleryItems.Count)
+                timer2.Stop();
+
+            maxLoadedItems++;
+            await UpdateToolBox();
         }
 
         /// <summary>


### PR DESCRIPTION
Applies lazy loading to available nodes in order to prevent the UI from freezing when opening the available nodes tab for the first time.